### PR TITLE
(MODULES-2709) Handle dead process

### DIFF
--- a/lib/puppet_x/puppetlabs/powershell_manager.rb
+++ b/lib/puppet_x/puppetlabs/powershell_manager.rb
@@ -83,6 +83,16 @@ module PuppetX::Dsc
         l = @stdout.gets
         Puppet.debug "#{Time.now} STDOUT> #{l}"
         output << l
+
+        # We need a way to get to process status.
+        # I'm not going to trust $? is going to
+        # give us the right thing. Especially on
+        # Windows.
+
+        #if !proc_thread.alive?
+        #  Puppet.debug "#{Time.now} #{cmd} has exited for unknown reasons."
+        #  raise "Process #{cmd} has exited, possibly due to malformed command."
+        #end
       end
 
       return output.join('')


### PR DESCRIPTION
Previously, if the process died, likely due to when the
process had a malformed command, it would endlessly loop
on stdout being readable (even though there was no output).

Instead, check to see if the process is still alive each time
through the loop and raise an error if the process is dead.
